### PR TITLE
Don't exclude servlet classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,6 @@
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>ch.qos.logback:*</exclude>
                                     <exclude>javax.ws.rs:*</exclude>
-                                    <exclude>javax.servlet:*</exclude>
                                 </excludes>
                             </artifactSet>
                         </configuration>


### PR DESCRIPTION
Broker does not provide javax.servlet.* so include it in the plugin. Fixes https://github.com/hivemq/hivemq-prometheus-extension/issues/5 